### PR TITLE
Add URL Button

### DIFF
--- a/embed.css
+++ b/embed.css
@@ -361,3 +361,16 @@ nav #date {
 .time {
 	white-space: pre !important;
 }
+
+.link {
+	/* inverted color style */
+	color: var(--theme-color) !important;
+	background-color: var(--theme-text-color);
+	text-decoration: none;
+	padding: 2px;
+	border: 1px solid var(--border-color);
+	border-radius: 5px;
+	margin-top: 3px;
+	margin-bottom: 3px;
+	display: inline-block;
+}

--- a/embed.js
+++ b/embed.js
@@ -146,7 +146,7 @@ function eventDetails(event) {
 		eDetails.appendChild(where);
 	}
 
-	if (event.description != '') {
+	if (event.description != null && event.description != '') {
 		eDetails.appendChild(document.createElement('br'));
 		let descLabel = document.createElement('strong');
 		descLabel.appendChild(document.createTextNode('Details: '));
@@ -155,6 +155,17 @@ function eventDetails(event) {
 		desc.innerHTML = urlify(event.description);
 		eDetails.appendChild(descLabel);
 		eDetails.appendChild(desc);
+	}
+
+	/* display a button for the event url */
+	if (event.url != null && event.url != '' && event.url.startsWith('http')) {
+		eDetails.appendChild(document.createElement('br'));
+		link = document.createElement('a');
+		link.href = event.url;
+		link.target = '_blank';
+		link.className = 'link';
+		link.appendChild(document.createTextNode("Mehr Informationen"));
+		eDetails.appendChild(link);
 	}
 
 	return eDetails;
@@ -504,11 +515,17 @@ function parseCalendar(data) {
 	for (let i = 0; i < eventData.length; i++) {
 		let event = new ICAL.Event(eventData[i]);
 		let duration = event.endDate.subtractDate(event.startDate);
+		/* the ICAL.Event Item Model has no access to the url property:
+		 * https://kewisch.github.io/ical.js/api/ICAL.Event.html
+		 * so we have to use the Component Model for this
+		 */
+		eventUrl = eventData[i].getFirstPropertyValue("url");
 		events.push({
 			uid: event.uid,
 			name: event.summary,
 			location: event.location || "TBA",
 			description: event.description,
+			url: eventUrl || "",
 			startDate: event.startDate.toJSDate(),
 			endDate: event.endDate.toJSDate(),
 			allDay: event.startDate.isDate,


### PR DESCRIPTION
This PR introduces a hyperlink-like button to open the current event's URL for additional information:
<img width="756" height="135" alt="image" src="https://github.com/user-attachments/assets/4313caea-ff57-469c-9cb5-694ea11a43a0" />
It also fixes the issue of displaying an empty description by checking whether `event.description != null`.